### PR TITLE
Fix registerMailTemplates for October CMS 3.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.1] - UNRELEASED
+
+### Fixed
+
+- Fixed `registerMailTemplates` logic for October CMS 3.6.
+  - Is backwards compatible with older October CMS versions.
+
 ## [3.2.0] - 2024-05-08
 
 ### Added

--- a/Plugin.php
+++ b/Plugin.php
@@ -93,7 +93,7 @@ final class Plugin extends PluginBase
     public function registerMailTemplates(): array
     {
         return [
-            'vdlp.horizon::mail.long-wait-detected' => 'Long Queue Wait Detected',
+            'vdlp.horizon::mail.long-wait-detected',
         ];
     }
 

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -8,3 +8,4 @@ v3.1.0:
   - 20220923_0001_create_job_batches_table.php
 v3.1.1: "Update Horizon Dashboard Layout (new UI)"
 v3.2.0: "Add support for Horizon 5.24.4"
+v3.2.1: "Fix registerMailTemplates for October CMS 3.6"

--- a/views/mail/long-wait-detected.htm
+++ b/views/mail/long-wait-detected.htm
@@ -1,4 +1,5 @@
 subject = "Long Queue Wait Detected"
+description = "Long Queue Wait Detected"
 ==
 The "{{ longWaitQueue }}" queue on the "{{ longWaitConnection }}" connection has a wait time of {{ seconds }} seconds.
 ==


### PR DESCRIPTION
The key-value structure of the method `registerMailTemplates` now uses the view path as the value. This change is part of the "Shorter Mail Templates" feature introduced in October CMS 3.6. 

See https://octobercms.com/support/article/rn-37 -> "Shorter Mail Templates" for more information.